### PR TITLE
Add button to generate downloadable calendar event

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ from flask import Flask, render_template, request, jsonify, send_from_directory
 from config import TARGET_ALTITUDE_DEG
 from hengefinder import search_for_henge
 import datetime
-from utils import get_location, get_coordinates, get_standardized_address, get_road_bearing, GeocodingError, check_latitude, get_utc_start_date, normalize_bearing_to_180_360
+from utils import get_location, get_coordinates, get_standardized_address, get_concise_address, get_road_bearing, GeocodingError, check_latitude, get_utc_start_date, normalize_bearing_to_180_360
 import traceback
 from astral import Observer, sun
 from sunset_calculator import calculate_sun_azimuths_for_year
@@ -76,6 +76,7 @@ def lookup_address():
             lat, lon = get_coordinates(location)
 
             standardized_address = get_standardized_address(location)
+            concise_address = get_concise_address(location)
             try:
                 check_latitude(lat)
             except ValueError as e:
@@ -117,6 +118,7 @@ def lookup_address():
             
             return jsonify({
                 'address': standardized_address,
+                'concise_address': concise_address,
                 'coordinates': {'lat': lat, 'lon': lon},
                 'road_bearing': round(road_bearing, 2),
                 'result': result
@@ -125,6 +127,7 @@ def lookup_address():
             # Just return address info for initial display
             return jsonify({
                 'address': standardized_address,
+                'concise_address': concise_address,
                 'coordinates': {'lat': lat, 'lon': lon},
                 'road_bearing': round(road_bearing, 2)
             })

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -372,29 +372,7 @@ async function addHengeToCalendar(data) {
         .replace(/;/g, '\\;')
         .replace(/\n/g, '\\n');
 
-    async function extractConciseLocation(address) {
-        const response = await fetch(`https://nominatim.openstreetmap.org/search?format=json&addressdetails=1&q=${encodeURIComponent(address)}`);
-        const data = await response.json();
-        const addr = data[0]?.address || {};
-
-        const locationDetails = {
-            street: addr.house_number && addr.road ? `${addr.house_number} ${addr.road}` : addr.road || null,
-            city: addr.city || addr.town || addr.village || addr.municipality || null,
-            state: addr.state || null,
-            postalCode: addr.postcode || null,
-            country: addr.country || null,
-        };
-
-        // Build a single-line string, filter out nulls, join with commas
-        return [
-            locationDetails.street,
-            locationDetails.city,
-            locationDetails.state && locationDetails.postalCode ? `${locationDetails.state} ${locationDetails.postalCode}` : locationDetails.state || locationDetails.postalCode,
-            locationDetails.country
-        ].filter(Boolean).join(', ');
-    }
-
-    const locationStr = await extractConciseLocation(data.address);
+    const locationStr = data.concise_address;
     const safeLocation = locationStr
         .replace(/,/g, '\\,')
         .replace(/;/g, '\\;');

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -353,6 +353,63 @@ function onMapMouseUp() {
     }
 }
 
+// Create .ics file for downloadable calendar event
+async function addHengeToCalendar(data) {
+    const start = new Date(data.result.henge_date);
+    const end = new Date(start.getTime() + 30 * 60 * 1000); // 30 mins
+
+    const formatDate = (date) =>
+        date.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+
+    const title = "Henge Alignment";
+    const description = `A perfect henge alignment is set for ${data.result.henge_time_local_str}!`;
+
+    const safeDescription = description
+        .replace(/,/g, '\\,')
+        .replace(/;/g, '\\;')
+        .replace(/\n/g, '\\n');
+
+    const safeLocation = data.address
+        .replace(/,/g, '\\,')
+        .replace(/;/g, '\\;')
+        .replace(/\n/g, '\\n');
+
+    function dedent(str) {
+        return str.replace(/^\s+/gm, '');
+    }
+
+    const icsContent = dedent(`
+        BEGIN:VCALENDAR
+        VERSION:2.0
+        PRODID:-//HengeFinder//EN
+        BEGIN:VEVENT
+        UID:${Date.now()}@hengefinder
+        DTSTAMP:${formatDate(new Date())}
+        DTSTART:${formatDate(start)}
+        DTEND:${formatDate(end)}
+        SUMMARY:${title}
+        DESCRIPTION:${safeDescription}
+        LOCATION:${safeLocation}
+        END:VEVENT
+        END:VCALENDAR
+    `).trim();
+
+    // Automatically download .ics file 
+    const blob = new Blob([icsContent], { type: "text/calendar" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+
+    a.href = url;
+    a.download = "henge-event.ics";
+
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+
+    console.log("ICS content:\n", icsContent);
+}
+
 // Calculate henge function
 async function calculateHenge() {
     const calculateBtn = document.getElementById('calculateHengeBtn');
@@ -379,6 +436,12 @@ async function calculateHenge() {
 
         if (response.ok) {
             displayResult(data);
+
+            // Generate calendar event to download
+            const calendarButton = document.getElementById("add-to-calendar");
+            if (calendarButton) {
+                calendarButton.addEventListener("click", () => addHengeToCalendar(data));
+            }
 
             // Replace interactive arrow with static arrows
             if (data.result.henge_found) {
@@ -497,6 +560,8 @@ function displayResult(data) {
                     <div class="disclaimer">
                         <p><span class="topic">Note: These predictions are rough estimates calculations.</span> For official city-wide henge events (like Manhattanhenge), check official announcements. They use specific city reference points and spatial assumptions, which may differ from the street-to-street calculations and assumptions used here.</p>
                     </div>
+                    <br/>
+                        <button id="add-to-calendar">Add to Calendar</button>
                 `;
         hengeResultDiv.className = 'result success';
     } else {

--- a/utils.py
+++ b/utils.py
@@ -48,6 +48,42 @@ def get_standardized_address(location):
     return location.address
 
 
+def get_concise_address(location):
+    """
+    Get a concise version of address
+    """
+    geolocator = Nominatim(
+        user_agent="HengeFinder", timeout=10
+    )  # longer timeout is needed for some addresses
+
+    rev = geolocator.reverse((location.latitude, location.longitude), addressdetails=True)
+    if rev is None:
+        raise GeocodingError(f"Could not reverse-geocode: {location.address}")
+    
+    addr = rev.raw.get("address", {})
+
+    # Extract fields with fallbacks
+    street = addr.get("road") or addr.get("residential") or addr.get("pedestrian")
+    city = (
+        addr.get("city")
+        or addr.get("town")
+        or addr.get("village")
+        or addr.get("hamlet")
+        or addr.get("suburb")
+    )
+    state = addr.get("state")
+    postcode = addr.get("postcode")
+    country = addr.get("country")
+
+    # Combine state with postcode (no comma separation) for parts assembly
+    state_post = f"{state} {postcode}".strip() if state or postcode else None
+
+    parts = [street, city, state_post, country]
+    concise = ", ".join(filter(None, parts))
+
+    return concise
+
+
 def get_utc_start_date():
     """
     Get today's date in UTC (standardized)


### PR DESCRIPTION
- Button added to Find a Henge (on successful henge)
- Clicking automatically downloads `.ics` file
  - compatible with both Apple & Google calendars
- Address parsed for brevity
  - concise version == location field
    - via async request to OpenStreetMap
    - easier to then generate map view in calendar
  - verbose (original) == part of description
- Other notes
  - duration pre-set for 30 mins 
  - timestamp / timezone will resolve as expected
    - see attached screenshot:
      - description says 18:56 CDT (local Chicago time)
      - event reports 7:56 (EDT, specific to my calendar settings) 
      - this is exactly what we want!
  
<img width="438" height="444" alt="Screenshot 2025-10-05 at 8 37 00 PM" src="https://github.com/user-attachments/assets/bddedc45-cf9c-48b2-9f84-e64ee78af1bb" />

<img width="732" height="402" alt="Screenshot 2025-10-05 at 8 38 14 PM" src="https://github.com/user-attachments/assets/2dc0f5b4-77a7-4d42-be47-b0bdfec53b99" />

<img width="1488" height="307" alt="Screenshot 2025-10-05 at 8 37 48 PM" src="https://github.com/user-attachments/assets/49bd1f2c-2e65-439d-8397-d35b262d510d" />
