### PR TITLE
Fix selecting city names that contain apostrophes in henge_near_me

### DIFF
--- a/static/js/henge_near_me.js
+++ b/static/js/henge_near_me.js
@@ -504,9 +504,12 @@ async function initializeCityInput() {
         ).slice(0, 10); // Limit to 10 suggestions
         
         if (filteredCities.length > 0) {
-            suggestions.innerHTML = filteredCities.map(city => 
-                `<div class="suggestion-item" onclick='selectCity("${city}")'>${city}</div>`
+            suggestions.innerHTML = filteredCities.map(city =>
+                `<div class="suggestion-item">${city}</div>`
             ).join('');
+            suggestions.querySelectorAll('.suggestion-item').forEach((el, i) => {
+                el.addEventListener('click', () => selectCity(filteredCities[i]));
+            });
             suggestions.style.display = 'block';
         } else {
             suggestions.style.display = 'none';


### PR DESCRIPTION
City names that contained apostrophes were early escaping some string-based html generation, particularly with adding click handlers. Move the click handler to javascript rather than the string.