### PR TITLE
Adding footer for OSM attribution

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -741,3 +741,20 @@ summary:hover {
         display: none;
     }
 }
+
+.site-footer {
+    text-align: center;
+    padding: 20px 0 10px;
+    margin-top: 30px;
+    color: #999;
+    font-size: 0.85em;
+}
+
+.site-footer a {
+    color: #996888;
+    text-decoration: none;
+}
+
+.site-footer a:hover {
+    text-decoration: underline;
+}

--- a/templates/henge_near_me.html
+++ b/templates/henge_near_me.html
@@ -66,6 +66,9 @@
         <div class="disclaimer">
             <p><span class="topic">Note: These predictions are rough estimate calculations.</span> For official city-wide henge events (like Manhattanhenge), check official announcements. They use specific city reference points and spatial assumptions, which may differ from the street-to-street calculations and assumptions used here.</p>
         </div>
+        <footer class="site-footer">
+            Street data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>
+        </footer>
     </div>
     <script src="{{ url_for('static', filename='js/road_filter.js') }}" defer></script>
     <script src="{{ url_for('static', filename='js/henge_near_me.js') }}" defer></script>

--- a/templates/index.html
+++ b/templates/index.html
@@ -220,6 +220,9 @@
                 </div>
             </div>
         </div>
+        <footer class="site-footer">
+            Street data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>
+        </footer>
     </div>
     <script src="{{ url_for('static', filename='js/app.js') }}" defer></script>
 </body>


### PR DESCRIPTION
Closes #15, to attribute OpenStreetMap. 

OSM is already attributed in the corner of the Leaflet maps, but it is also used both for the maps and also for street bearing calculations. This PR adds attribution to the bottom of each page. 