### PR TITLE
adding link to mobile app

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Some sample addresses:
 - `601-615 E 76th St, Chicago, IL` 
 - `3131 Market St, Philadelphia, PA 19104`
 
+## Mobile App
+
+For the full mobile experience, download the Hengefinder app at [hengefinder.com](https://hengefinder.com).
+
 ## How It Works
 
 The algorithm searches for dates when the sun's azimuth at 0.5 degrees elevation (shortly before sunset) aligns with the street's bearing.

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -758,3 +758,17 @@ summary:hover {
 .site-footer a:hover {
     text-decoration: underline;
 }
+
+.mobile-app-note {
+    margin-bottom: 6px;
+    color: #999;
+}
+
+.mobile-app-note a {
+    color: #996888;
+    text-decoration: none;
+}
+
+.mobile-app-note a:hover {
+    text-decoration: underline;
+}

--- a/templates/henge_near_me.html
+++ b/templates/henge_near_me.html
@@ -67,6 +67,7 @@
             <p><span class="topic">Note: These predictions are rough estimate calculations.</span> For official city-wide henge events (like Manhattanhenge), check official announcements. They use specific city reference points and spatial assumptions, which may differ from the street-to-street calculations and assumptions used here.</p>
         </div>
         <footer class="site-footer">
+            <div class="mobile-app-note">Want Hengefinder on the go? <a href="https://hengefinder.com" target="_blank">Get the mobile app</a></div>
             Street data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>
         </footer>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -221,6 +221,7 @@
             </div>
         </div>
         <footer class="site-footer">
+            <div class="mobile-app-note">Want Hengefinder on the go? <a href="https://hengefinder.com" target="_blank">Get the mobile app</a></div>
             Street data &copy; <a href="https://www.openstreetmap.org/copyright" target="_blank">OpenStreetMap contributors</a>
         </footer>
     </div>


### PR DESCRIPTION
Adding a link the https://hengefinder.com/ mobile app, in the web app itself and the readme.